### PR TITLE
Fix export file procedures

### DIFF
--- a/spExportTableToXmlFile.sql
+++ b/spExportTableToXmlFile.sql
@@ -5,13 +5,13 @@
 *  Use stored procedure : #spWriteStringToFile
 *
 *  Syntax :
-*  EXEC #spExportTableToXmlFile @SchemaName = 'dbo', @TableName = 'User', @Path = 'C:\Temp\', @Filename = 'user.xml';
+*  EXEC #spExportTableToXmlFile @SchemaName = 'dbo', @TableName = 'User', @Path = 'C:\Temp\', @FileName = 'user.xml';
 *
 */
 CREATE OR ALTER PROCEDURE #spExportTableToXmlFile
 ( @SchemaName VARCHAR(255)
-, @TableName VARCHAR(255) 
-, @Path VARCHAR(255)      
+, @TableName VARCHAR(255)
+, @Path VARCHAR(255)
 , @FileName VARCHAR(512)   = NULL
 , @SafeMode INT = 0
 , @CreateXSDFile INT = 0
@@ -22,11 +22,11 @@ BEGIN
     
 	SET NOCOUNT ON;
 
-	IF (@Filename IS NULL)
-	BEGIN
-		SET @Filename = @SchemaName+'.' COLLATE DATABASE_DEFAULT +@TableName+'.xml' COLLATE DATABASE_DEFAULT;
-		IF (@CreateXSDFile = 1) SET @Filename = @SchemaName+'.' COLLATE DATABASE_DEFAULT +@TableName+'.xsd' COLLATE DATABASE_DEFAULT;
-	END
+        IF (@FileName IS NULL)
+        BEGIN
+                SET @FileName = @SchemaName+'.' COLLATE DATABASE_DEFAULT +@TableName+'.xml' COLLATE DATABASE_DEFAULT;
+                IF (@CreateXSDFile = 1) SET @FileName = @SchemaName+'.' COLLATE DATABASE_DEFAULT +@TableName+'.xsd' COLLATE DATABASE_DEFAULT;
+        END
 	-- TODO : Clean up invalided chars
 
 	DECLARE @Template NVARCHAR(MAX) = '
@@ -35,7 +35,7 @@ PRINT ''-- Export Table to Xml File : [@(SchemaName)].[@(TableName)]''
 PRINT ''-- '' + CONVERT(VARCHAR(50), GETDATE(), 121);
 DECLARE @xml varchar(max);
 SET @xml = (select * from [@(SchemaName)].[@(TableName)] FOR XML AUTO, ROOT (''@(SchemaName).@(TableName)''))
-EXEC #spWriteStringToFile @String = @xml, @Path = ''@(Path)'', @Filename  = ''@(Filename)'';
+EXEC #spWriteStringToFile @File = N''@(Path)@(FileName)'', @Text = @xml;
 ' COLLATE DATABASE_DEFAULT
 
     IF (@CreateXSDFile = 1)
@@ -46,14 +46,14 @@ PRINT ''-- Export Table to Xml File : [@(SchemaName)].[@(TableName)]''
 PRINT ''-- '' + CONVERT(VARCHAR(50), GETDATE(), 121);
 DECLARE @xml varchar(max);
 SET @xml = (select TOP 0 * from [@(SchemaName)].[@(TableName)] FOR XML AUTO, ELEMENTS, XMLSCHEMA )
-EXEC #spWriteStringToFile @String = @xml, @Path = ''@(Path)'', @Filename  = ''@(Filename)'';
+EXEC #spWriteStringToFile @File = N''@(Path)@(FileName)'', @Text = @xml;
 ' COLLATE DATABASE_DEFAULT
 	END
 
 	SET @Template = REPLACE(@Template,'@(SchemaName)' COLLATE DATABASE_DEFAULT , @SchemaName);
 	SET @Template = REPLACE(@Template,'@(TableName)' COLLATE DATABASE_DEFAULT , @TableName);
-	SET @Template = REPLACE(@Template,'@(Path)' COLLATE DATABASE_DEFAULT , @Path);
-	SET @Template = REPLACE(@Template,'@(Filename)' COLLATE DATABASE_DEFAULT , @Filename);
+        SET @Template = REPLACE(@Template,'@(Path)' COLLATE DATABASE_DEFAULT , @Path);
+        SET @Template = REPLACE(@Template,'@(FileName)' COLLATE DATABASE_DEFAULT , @FileName);
 
 	IF (@Debug = 1) PRINT @Template
 	IF (@SafeMode = 1)

--- a/spWriteStringToFile.sql
+++ b/spWriteStringToFile.sql
@@ -47,10 +47,8 @@ GO
 
 	--Commit data and close text stream
 	EXECUTE sp_OAMethod                  @OLE,    'SaveToFile',       NULL,       @File, 2   --1 = notexist 2 = overwrite
-	EXECUTE sp_OAMethod                  @OLE,    'Close'
-	EXECUTE sp_OADestroy                 @OLE
-
-	EXECUTE sp_OADestroy @OLE 
+        EXECUTE sp_OAMethod                  @OLE,    'Close'
+        EXECUTE sp_OADestroy                 @OLE
 
 END 
 GO


### PR DESCRIPTION
## Summary
- fix parameter names in spExportTableToXmlFile
- join path and filename when writing file
- clean up duplicate sp_OADestroy call in spWriteStringToFile

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_685a9fb0d45c832894d40a1ff692152e